### PR TITLE
Ignore "node_modules" in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/


### PR DESCRIPTION
This PR adds `.gitignore` file to project and let `node_modules` directory to be ignored by Git so `git status` will remain clean when dependencies are installed locally