### PR TITLE
Disable Nunjucks engine when page is being rendered using Twig

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -26,4 +26,6 @@ twigRenderer.compile = function(data) {
     }
 };
 
+twigRenderer.disableNunjucks = true;
+
 module.exports = twigRenderer;


### PR DESCRIPTION
As per Hexo PR [#2593](https://github.com/hexojs/hexo/pull/2593) it is now possible to disable embedded Nunjucks rendering engine if actual page renderer conflicts with it. Since Twig and Nunjucks are syntactically very similar - it is necessary to use this feature so no additional Nunjucks processing will take place.