### PR TITLE
Expose Twig through Hexo Twig renderer

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -26,4 +26,6 @@ twigRenderer.compile = function(data) {
     }
 };
 
+twigRenderer.twig = Twig;
+
 module.exports = twigRenderer;


### PR DESCRIPTION
Twig engine by itself is [extensible](https://github.com/twigjs/twig.js/wiki/Extending-twig.js) with custom filters and functions and Hexo have support for [local scripts](https://hexo.io/docs/plugins#Script) to allow such extensions. 

But in order to be able to apply extensions to Twig it is necessary to have Twig itself to be exposed. This simple PR allows local scripts and Hexo plugins to access Twig engine, used by renderer.